### PR TITLE
#2 Fixed issue for making gap string as const.

### DIFF
--- a/pset1/mario/mario.c
+++ b/pset1/mario/mario.c
@@ -4,6 +4,7 @@ void print_blocks(int num);
 
 const int NUM_LIMIT = 23;
 // TODO: Gap string should be used as const
+const char GAP_STRING[] = "|  |";
 
 int main(void)
 {
@@ -23,7 +24,7 @@ int main(void)
         }
         print_blocks(i + 1);
         // Gaps
-        printf("|  |");
+        printf("%s", GAP_STRING);
         // Right blocks
         print_blocks(i + 1);
         printf("\n");


### PR DESCRIPTION
use `const` statements to compiler, allow user to set strings of gap between blocks.